### PR TITLE
update usage example to match examples/entities.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,14 @@ go get github.com/mlabouardy/dialogflow-go-client
 # Usage
 
 * Create `main.go` file with the following code:
+
 ```golang
 package main
 
 import (
 	"fmt"
-	"github.com/mlabouardy/dialogflow-go-client"
-	"github.com/mlabouardy/dialogflow-go-client/models"
+	. "github.com/mlabouardy/dialogflow-go-client"
+	. "github.com/mlabouardy/dialogflow-go-client/models"
 	"log"
 )
 


### PR DESCRIPTION
## Problem
`gofmt` will think `github.com/mlabouardy/dialogflow-go-client` and `github.com/mlabouardy/dialogflow-go-client/models` are not used and will remove them on save.

## Fix
Updated the usage example in `README.md` to match `examples/entities.go` for the usage example to work correctly.