### PR TITLE
add resetContexts to param when using QueryFindRequest

### DIFF
--- a/models/query.go
+++ b/models/query.go
@@ -3,6 +3,7 @@ package models
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 )
 
 type Query struct {
@@ -53,6 +54,7 @@ func (query Query) ToMap() map[string]string {
 	params["v"] = query.V
 	params["sessionId"] = query.SessionID
 	params["lang"] = query.Lang
+	params["resetContexts"] = strconv.FormatBool(query.ResetContexts)
 
 	return params
 }


### PR DESCRIPTION
## Problem

when using QueryFindRequest there is no resetContexts paramater

Example query:
```
Query{
    Query: "reset contexts",
    ResetContexts: true,
    SessionID: "testSession",
}
```

Original (resetContexts does not exist):
```json
{
    "lang":"en",
    "query":"reset contexts",
    "sessionId":"testSession",
    "v":""
}
```

## Fix

add resetContexts to ToMap so that it will be present when passing a Query that contains resetContexts to QueryFindRequest

After fix:
```json
{
    "lang":"en",
    "query":"reset contexts",
    "resetContexts":"true",
    "sessionId":"testSession",
    "v":""
}
```