### PR TITLE
Support response message type from dialogflow sometime is string,

### DIFF
--- a/models/message.go
+++ b/models/message.go
@@ -1,6 +1,6 @@
 package models
 
 type Message struct {
-	Type   int    `json:"type,omitempty"`
-	Speech string `json:"speech,omitempty"`
+	Type   interface{} `json:"type,omitempty"`
+	Speech string      `json:"speech,omitempty"`
 }


### PR DESCRIPTION
From dialogflow response, sometime the `Type` is number, sometime is string. So need to support to make sure the Unmarshal function don't crash and fail the flow